### PR TITLE
Allow image to run as a group other than zero

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 1and1internet/ubuntu-16-nginx:latest
+FROM 1and1internet/ubuntu-16-nginx
 MAINTAINER james.eckersall@1and1.co.uk
 ARG DEBIAN_FRONTEND=noninteractive
 COPY files /

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,3 @@ RUN \
     chmod -R 777 /var/www/html /var/log && \
     sed -i -e 's/index index.html/index index.php index.html/g' /etc/nginx/sites-enabled/site.conf && \
     chmod 666 /etc/nginx/sites-enabled/site.conf /etc/passwd /etc/group
-EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ RUN \
     chmod 755 /hooks /var/www && \
     chmod -R 777 /var/www/html /var/log && \
     sed -i -e 's/index index.html/index index.php index.html/g' /etc/nginx/sites-enabled/site.conf && \
-    chmod 666 /etc/nginx/sites-enabled/site.conf
+    chmod 666 /etc/nginx/sites-enabled/site.conf /etc/passwd /etc/group
 EXPOSE 8080


### PR DESCRIPTION
At current this image will exit with status code 1 if run as a group other than zero. This is as a result of the package installation done within this Dockerfile changing the permissions on the passwd file. This introduces a chmod which sets it back to the necessary permissions.

`docker run -i -t --rm --user=9999:9999 1and1internet/ubuntu-16-nginx-php-5.6 `
